### PR TITLE
`cloudflared` service improvements

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -738,6 +738,7 @@
   ./services/networking/charybdis.nix
   ./services/networking/cjdns.nix
   ./services/networking/cloudflare-dyndns.nix
+  ./services/networking/cloudflared.nix
   ./services/networking/cntlm.nix
   ./services/networking/connman.nix
   ./services/networking/consul.nix

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -1,0 +1,95 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.cloudflared;
+in
+{
+  meta.maintainers = with maintainers; [ bbigras ];
+
+  options.services.cloudflared = {
+    enable = mkEnableOption "Cloudflared Argo Tunnel client daemon";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.cloudflared;
+      defaultText = "pkgs.cloudflared";
+      description = "The package to use for Cloudflared.";
+    };
+
+    tunnels = mkOption {
+      description = ''
+        Cloudflare tunnels.
+      '';
+      type = types.attrsOf (types.submodule ({ name, ... }: {
+        options = {
+          tunnel = mkOption {
+            type = with types; nullOr str;
+            default = null;
+            description = ''
+              Tunnel ID or name.
+            '';
+            example = "00000000-0000-0000-0000-000000000000";
+          };
+
+          credentialsFile = mkOption {
+            type = with types; nullOr str;
+            default = null;
+            description = ''
+              Credential file.
+            '';
+          };
+
+          default = mkOption {
+            type = with types; nullOr str;
+            default = null;
+            description = ''
+              Catch-all if no ingress matches.
+            '';
+            example = "http_status:404";
+          };
+
+          ingress = mkOption {
+            type = types.attrsOf types.str;
+            default = { };
+            example = {
+              "*.domain.com" = "http://localhost:80";
+              "*.anotherone.com" = "http://localhost:80";
+            };
+          };
+        };
+      }));
+
+      default = { };
+    };
+  };
+
+  config = {
+    systemd.services =
+      mapAttrs'
+        (name: tunnel:
+          let
+            fullConfig = {
+              tunnel = name;
+              "credentials-file" = tunnel.credentialsFile;
+              ingress = (map
+                (key: {
+                  hostname = key;
+                  service = getAttr key tunnel.ingress;
+                })
+                (attrNames tunnel.ingress)) ++ [{ service = tunnel.default; }];
+            };
+            mkConfigFile = pkgs.writeText "cloudflared.yml" (builtins.toJSON fullConfig);
+          in
+          nameValuePair "cloudflared-tunnel-${name}" ({
+            after = [ "network.target" ];
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              ExecStart = "${cfg.package}/bin/cloudflared tunnel --config=${mkConfigFile} --no-autoupdate run";
+              Restart = "always";
+            };
+          })
+        )
+        config.services.cloudflared.tunnels;
+  };
+}

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -175,7 +175,7 @@ in
             description = ''
               Credential file.
 
-              It seems to be a json those keys: <literal>AccountTag</literal>, <literal>TunnelSecret</literal>, <literal>TunnelID</literal> and <literal>TunnelName</literal>.
+              See <link xlink:href="https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-useful-terms/#credentials-file">Credentials file</link>.
             '';
           };
 

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -2,7 +2,141 @@
 
 with lib;
 
-let cfg = config.services.cloudflared;
+let
+  cfg = config.services.cloudflared;
+
+  originRequest = {
+    connectTimeout = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "30s";
+      description = ''
+        Timeout for establishing a new TCP connection to your origin server. This excludes the time taken to establish TLS, which is controlled by <link xlink:href="https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/local-management/ingress/#tlstimeout">tlsTimeout</link>.
+      '';
+    };
+
+    tlsTimeout = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "10s";
+      description = ''
+        Timeout for completing a TLS handshake to your origin server, if you have chosen to connect Tunnel to an HTTPS server.
+      '';
+    };
+
+    tcpKeepAlive = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "30s";
+      description = ''
+        The timeout after which a TCP keepalive packet is sent on a connection between Tunnel and the origin server.
+      '';
+    };
+
+    noHappyEyeballs = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      example = false;
+      description = ''
+        Disable the “happy eyeballs” algorithm for IPv4/IPv6 fallback if your local network has misconfigured one of the protocols.
+      '';
+    };
+
+    keepAliveConnections = mkOption {
+      type = with types; nullOr int;
+      default = null;
+      example = 100;
+      description = ''
+        Maximum number of idle keepalive connections between Tunnel and your origin. This does not restrict the total number of concurrent connections.
+      '';
+    };
+
+    keepAliveTimeout = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "1m30s";
+      description = ''
+        Timeout after which an idle keepalive connection can be discarded.
+      '';
+    };
+
+    httpHostHeader = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "";
+      description = ''
+        Sets the HTTP <literal>Host</literal> header on requests sent to the local service.
+      '';
+    };
+
+    originServerName = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "";
+      description = ''
+        Hostname that <literal>cloudflared</literal> should expect from your origin server certificate.
+      '';
+    };
+
+    caPool = mkOption {
+      type = with types; nullOr (either str path);
+      default = null;
+      example = "";
+      description = ''
+        Path to the certificate authority (CA) for the certificate of your origin. This option should be used only if your certificate is not signed by Cloudflare.
+      '';
+    };
+
+    noTLSVerify = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      example = false;
+      description = ''
+        Disables TLS verification of the certificate presented by your origin. Will allow any certificate from the origin to be accepted.
+      '';
+    };
+
+    disableChunkedEncoding = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      example = false;
+      description = ''
+        Disables chunked transfer encoding. Useful if you are running a WSGI server.
+      '';
+    };
+
+    proxyAddress = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "127.0.0.1";
+      description = ''
+        <literal>cloudflared</literal> starts a proxy server to translate HTTP traffic into TCP when proxying, for example, SSH or RDP. This configures the listen address for that proxy.
+      '';
+    };
+
+    proxyPort = mkOption {
+      type = with types; nullOr int;
+      default = null;
+      example = 0;
+      description = ''
+        <literal>cloudflared</literal> starts a proxy server to translate HTTP traffic into TCP when proxying, for example, SSH or RDP. This configures the listen port for that proxy. If set to zero, an unused port will randomly be chosen.
+      '';
+    };
+
+    proxyType = mkOption {
+      type = with types; nullOr (enum [ "" "socks" ]);
+      default = null;
+      example = "";
+      description = ''
+        <literal>cloudflared</literal> starts a proxy server to translate HTTP traffic into TCP when proxying, for example, SSH or RDP. This configures what type of proxy will be started. Valid options are:
+
+        <itemizedlist>
+            <listitem><para><literal>""</literal> for the regular proxy</para></listitem>
+            <listitem><para><literal>"socks"</literal> for a SOCKS5 proxy. Refer to the <link xlink:href="https://developers.cloudflare.com/cloudflare-one/tutorials/kubectl/">tutorial on connecting through Cloudflare Access using kubectl</link> for more information.</para></listitem>
+        </itemizedlist>
+      '';
+    };
+  };
 in
 {
   meta.maintainers = with maintainers; [ bbigras ];
@@ -23,6 +157,8 @@ in
       '';
       type = types.attrsOf (types.submodule ({ name, ... }: {
         options = {
+          inherit originRequest;
+
           tunnel = mkOption {
             type = with types; nullOr str;
             default = null;
@@ -50,8 +186,34 @@ in
           };
 
           ingress = mkOption {
-            type = types.attrsOf types.str;
+            type = types.attrsOf (types.submodule ({ hostname, ... }: {
+              options = {
+                inherit originRequest;
+
+                service = mkOption {
+                  type = with types; nullOr str;
+                  default = null;
+                  description = ''
+                    TODO
+                  '';
+                  example = "http://localhost:80, tcp://localhost:8000, unix:/home/production/echo.sock, hello_world or http_status:404";
+                };
+
+                path = mkOption {
+                  type = with types; nullOr str;
+                  default = null;
+                  description = ''
+                    TODO
+                  '';
+                  example = "/*.(jpg|png|css|js)";
+                };
+
+              };
+            }));
             default = { };
+            description = ''
+              TODO
+            '';
             example = {
               "*.domain.com" = "http://localhost:80";
               "*.anotherone.com" = "http://localhost:80";
@@ -69,14 +231,15 @@ in
       mapAttrs'
         (name: tunnel:
           let
+            filterConfig = lib.attrsets.filterAttrsRecursive (_: v: ! builtins.elem v [ null [ ] { } ]);
+
             fullConfig = {
               tunnel = name;
               "credentials-file" = tunnel.credentialsFile;
               ingress = (map
                 (key: {
                   hostname = key;
-                  service = getAttr key tunnel.ingress;
-                })
+                } // getAttr key (filterConfig (filterConfig tunnel.ingress)))
                 (attrNames tunnel.ingress)) ++ [{ service = tunnel.default; }];
             };
             mkConfigFile = pkgs.writeText "cloudflared.yml" (builtins.toJSON fullConfig);


### PR DESCRIPTION
## originCert
I found that `cloudflared` _sometimes_ wanted access to the original certificate during testing, so I added a nullable `originCert` option.  Looking at it now, it probably needs a `mkIf (tunnel.originCert != null)` in the configuration definition.  I'll come back to that if you think it's necessary.

## credentialsFile
`types.path` suites it better.

## warp-routing.enabled
- added to configuration file - it was missing.
- default to `false`, since it's going into the file regardless of the value.

## default ingress
Default to HTTP status 404.  One less thing to spell out in the system configuration.

## add cloudflared as a system package
Many other services do this.

## refine the systemd service unit
- used the approach _you_ described in [this forum post](https://discourse.nixos.org/t/using-cloudflared-with-zero-trust-dashboard-on-nixos/19069/8?u=daf).
- added a `RestartSec` setting, since it restarted too quickly to be useful during testing w/ a failing tunnel.
- appended `warp-svc` to the `after` rule b/c of the `warp-routing.enabled` option.  This is based on the work @WolfangAukang is doing in [this PR](https://github.com/NixOS/nixpkgs/pull/168092).